### PR TITLE
Adding a bug fix to trim Sentinel Host Names.

### DIFF
--- a/ctstone.Redis/RedisSentinelManager.cs
+++ b/ctstone.Redis/RedisSentinelManager.cs
@@ -20,7 +20,7 @@ namespace ctstone.Redis
             foreach (var host in sentinels)
             {
                 string[] parts = host.Split(':');
-                string hostname = parts[0];
+                string hostname = parts[0].Trim();
                 int port = Int32.Parse(parts[1]);
                 _sentinels.AddLast(new KeyValuePair<string, int>(hostname, port));
             }


### PR DESCRIPTION
Contributing a bug fix to deal with leading/trailing spaces in the Host Names. This can cause a failover to fail if the secondary host name has leading/trailing spaces.
