### PR TITLE
Fixed wrongly calculated message length when there are none ASCII symbol...

### DIFF
--- a/ctstone.Redis/RedisConnection.cs
+++ b/ctstone.Redis/RedisConnection.cs
@@ -372,7 +372,7 @@ namespace ctstone.Redis
                 {
                     cmd_builder
                         .Append(Bulk)
-                        .Append(arg.Length)
+                        .Append(_encoding.GetBytes(arg).Length)
                         .Append(EOL);
                     cmd_builder
                         .Append(arg)


### PR DESCRIPTION
It was wrongly assumed that the length of a string is the same after UTF8 encoding, which is not true for none ASCII symbols. This was causing Redis to trim the message.
