### PR TITLE
support reading of binary byte strings via configuration of appropriate encoding

### DIFF
--- a/ctstone.Redis.Tests/RedisClientTests/RedisStringTests.cs
+++ b/ctstone.Redis.Tests/RedisClientTests/RedisStringTests.cs
@@ -51,6 +51,29 @@ namespace ctstone.Redis.Tests.RedisClientTests
         }
 
         [TestMethod, TestCategory("Strings")]
+        public void TestByteString()
+        {
+            // use an encoding with 256 8 bit characters
+            Encoding DefaultEncoding = RedisClient.Encoding;
+            RedisClient.Encoding = Encoding.GetEncoding("Windows-1252");
+
+            using (new RedisTestKeys(Redis, "test1"))
+            {
+                byte[] bytes = new byte[] { 0x00, 0x8F };
+                Redis.Set("test1", bytes);
+
+                byte[] buffer = RedisClient.Encoding.GetBytes(Redis.Get("test1"));
+
+                // change encoding back for other tests running in the same process
+                RedisClient.Encoding = DefaultEncoding;
+
+                Assert.AreEqual(bytes.Length, buffer.Length);
+                for (int i = 0; i < bytes.Length; i++)
+                    Assert.AreEqual(bytes[i], buffer[i]);
+            }
+        }
+
+        [TestMethod, TestCategory("Strings")]
         public void TestAppend()
         {
             Redis.Del("test");

--- a/ctstone.Redis/RedisClient.cs
+++ b/ctstone.Redis/RedisClient.cs
@@ -36,6 +36,15 @@ namespace ctstone.Redis
         public int Port { get { return _connection.Port; } }
 
         /// <summary>
+        /// Globally used string encoding for RedisConnection.
+        /// </summary>
+        public static Encoding Encoding
+        {
+            get { return RedisConnection.Encoding; }
+            set { RedisConnection.Encoding = value; }
+        }
+
+        /// <summary>
         /// Occurs when a subscription message has been received
         /// </summary>
         public event EventHandler<RedisSubscriptionReceivedEventArgs> SubscriptionReceived;

--- a/ctstone.Redis/RedisCommands/RedisDateMicro.cs
+++ b/ctstone.Redis/RedisCommands/RedisDateMicro.cs
@@ -11,7 +11,7 @@ namespace ctstone.Redis.RedisCommands
 
         private static DateTime ParseStream(Stream stream)
         {
-            string[] parts = RedisReader.ReadMultiBulkUTF8(stream);
+            string[] parts = RedisReader.ReadMultiBulkString(stream);
             int timestamp = Int32.Parse(parts[0]);
             int microseconds = Int32.Parse(parts[1]);
             long ticks = microseconds * (TimeSpan.TicksPerMillisecond / 1000);

--- a/ctstone.Redis/RedisCommands/RedisFloat.cs
+++ b/ctstone.Redis/RedisCommands/RedisFloat.cs
@@ -12,7 +12,7 @@ namespace ctstone.Redis.RedisCommands
 
         private static double ParseStream(Stream stream)
         {
-            return Double.Parse(RedisReader.ReadBulkUTF8(stream), NumberStyles.Float);
+            return Double.Parse(RedisReader.ReadBulkString(stream), NumberStyles.Float);
         }
     }
 
@@ -24,7 +24,7 @@ namespace ctstone.Redis.RedisCommands
 
         private static double? ParseStream(Stream stream)
         {
-            string result = RedisReader.ReadBulkUTF8(stream);
+            string result = RedisReader.ReadBulkString(stream);
             if (result == null)
                 return null;
             return Double.Parse(result, NumberStyles.Float);

--- a/ctstone.Redis/RedisCommands/RedisHash.cs
+++ b/ctstone.Redis/RedisCommands/RedisHash.cs
@@ -14,7 +14,7 @@ namespace ctstone.Redis.RedisCommands
 
         private static Dictionary<string, string> ParseStream(Stream stream)
         {
-            string[] fieldValues = RedisReader.ReadMultiBulkUTF8(stream);
+            string[] fieldValues = RedisReader.ReadMultiBulkString(stream);
             return HashMapper.ToDict(fieldValues);
         }
     }
@@ -28,7 +28,7 @@ namespace ctstone.Redis.RedisCommands
 
         private static T ParseStream(Stream stream)
         {
-            string[] fieldValues = RedisReader.ReadMultiBulkUTF8(stream);
+            string[] fieldValues = RedisReader.ReadMultiBulkString(stream);
             return HashMapper.ToObject<T>(fieldValues);
         }
     }

--- a/ctstone.Redis/RedisCommands/RedisHashes.cs
+++ b/ctstone.Redis/RedisCommands/RedisHashes.cs
@@ -35,7 +35,7 @@ namespace ctstone.Redis.RedisCommands
 
         private static Dictionary<string, string>[] ParseStream(Stream stream, string[] fields)
         {
-            string[] response = RedisReader.ReadMultiBulkUTF8(stream);
+            string[] response = RedisReader.ReadMultiBulkString(stream);
 
             Dictionary<string, string>[] dicts = new Dictionary<string, string>[response.Length / fields.Length];
             for (int i = 0; i < response.Length; i += fields.Length)

--- a/ctstone.Redis/RedisCommands/RedisIntNull.cs
+++ b/ctstone.Redis/RedisCommands/RedisIntNull.cs
@@ -14,7 +14,7 @@ namespace ctstone.Redis.RedisCommands
             if (type == RedisMessage.Int)
                 return RedisReader.ReadInt(stream, false);
 
-            RedisReader.ReadBulkUTF8(stream, false);
+            RedisReader.ReadBulkString(stream, false);
             return null;
         }
     }

--- a/ctstone.Redis/RedisCommands/RedisString.cs
+++ b/ctstone.Redis/RedisCommands/RedisString.cs
@@ -4,7 +4,7 @@ namespace ctstone.Redis.RedisCommands
     class RedisString : RedisCommand<string>
     {
         public RedisString(string command, params object[] args)
-            : base(RedisReader.ReadBulkUTF8, command, args)
+            : base(RedisReader.ReadBulkString, command, args)
         { }
     }
 }

--- a/ctstone.Redis/RedisCommands/RedisStringNull.cs
+++ b/ctstone.Redis/RedisCommands/RedisStringNull.cs
@@ -12,7 +12,7 @@ namespace ctstone.Redis.RedisCommands
         {
             var type = RedisReader.ReadType(stream);
             if (type == RedisMessage.Bulk)
-                return RedisReader.ReadBulkUTF8(stream, false);
+                return RedisReader.ReadBulkString(stream, false);
             RedisReader.ReadMultiBulk(stream, false);
             return null;
         }

--- a/ctstone.Redis/RedisCommands/RedisStrings.cs
+++ b/ctstone.Redis/RedisCommands/RedisStrings.cs
@@ -4,7 +4,7 @@ namespace ctstone.Redis.RedisCommands
     class RedisStrings : RedisCommand<string[]>
     {
         public RedisStrings(string command, params object[] args)
-            : base(RedisReader.ReadMultiBulkUTF8, command, args)
+            : base(RedisReader.ReadMultiBulkString, command, args)
         { }
     }
 }

--- a/ctstone.Redis/RedisCommands/RedisTuple.cs
+++ b/ctstone.Redis/RedisCommands/RedisTuple.cs
@@ -11,7 +11,7 @@ namespace ctstone.Redis.RedisCommands
         { }
         protected static Tuple<string, string> ParseStream(Stream stream)
         {
-            string[] result = RedisReader.ReadMultiBulkUTF8(stream);
+            string[] result = RedisReader.ReadMultiBulkString(stream);
             if (result == null)
                 return null;
             return Tuple.Create(result[0], result[1]);
@@ -25,7 +25,7 @@ namespace ctstone.Redis.RedisCommands
         { }
         protected static Tuple<Item1, Item2> ParseStream(Stream stream)
         {
-            string[] result = RedisReader.ReadMultiBulkUTF8(stream);
+            string[] result = RedisReader.ReadMultiBulkString(stream);
             if (result == null)
                 return null;
 

--- a/ctstone.Redis/RedisCommands/RedisValue.cs
+++ b/ctstone.Redis/RedisCommands/RedisValue.cs
@@ -9,7 +9,7 @@ namespace ctstone.Redis.RedisCommands
         { }
         private static string ParseStream(Stream stream)
         {
-            string[] result = RedisReader.ReadMultiBulkUTF8(stream);
+            string[] result = RedisReader.ReadMultiBulkString(stream);
             if (result == null)
                 return null;
             return result[1];

--- a/ctstone.Redis/RedisConnection.cs
+++ b/ctstone.Redis/RedisConnection.cs
@@ -57,6 +57,16 @@ namespace ctstone.Redis
         private readonly object _asyncLock;
         private long _bytesRemaining;
         private ActivityTracer _activity;
+
+        /// <summary>
+        /// Globally used string encoding. Default is UTF8 for international characters.
+        /// Can be changed to e.g. Windows-1252 to support binary byte strings instead.
+        /// </summary>
+        public static Encoding Encoding
+        {
+            get { return _encoding; }
+            set { _encoding = value; }
+        }
         
         /// <summary>
         /// Instantiate new instance of RedisConnection

--- a/ctstone.Redis/RedisReader.cs
+++ b/ctstone.Redis/RedisReader.cs
@@ -42,16 +42,16 @@ namespace ctstone.Redis
         }
 
         // redis type == BULK
-        public static string ReadBulkUTF8(Stream stream)
+        public static string ReadBulkString(Stream stream)
         {
-            return ReadBulkUTF8(stream, true);
+            return ReadBulkString(stream, true);
         }
-        public static string ReadBulkUTF8(Stream stream, bool checkType)
+        public static string ReadBulkString(Stream stream, bool checkType)
         {
             byte[] bulk = ReadBulk(stream, checkType);
             if (bulk == null)
                 return null;
-            return Encoding.UTF8.GetString(bulk);
+            return RedisConnection.Encoding.GetString(bulk);
         }
         public static byte[] ReadBulk(Stream stream)
         {
@@ -114,7 +114,7 @@ namespace ctstone.Redis
         }
 
         // redis type == MULTIBULK
-        public static string[] ReadMultiBulkUTF8(Stream stream)
+        public static string[] ReadMultiBulkString(Stream stream)
         {
             object[] result = ReadMultiBulk(stream);
             if (result == null)
@@ -150,7 +150,7 @@ namespace ctstone.Redis
             switch (type)
             {
                 case RedisMessage.Bulk:
-                    return ReadBulkUTF8(stream, false);
+                    return ReadBulkString(stream, false);
 
                 case RedisMessage.Int:
                     return ReadInt(stream, false);


### PR DESCRIPTION
csredis is great in its close mapping of the Redis API to C#. The mapping of binary safe Redis strings to UTF8 encoded C# text strings limits the applicability though. On can generally not write and read back binary data, such as image data or serialized data structures.

The recent additions to csredis indicate that there is interest in supporting binary data as well, so far for writing. This pull request addresses the reading. There finds several possible solutions to overcome this limitation.

RedisClientTests.RedisStringTests.TestRawBytes bypasses RedisReader and directly accesses the raw bytes. The drawback of this solution is that the simplicity of the direct mapping of the Redis API is lost.

Another solution might be to extend the Redis commands. For instance one may extend RedisClient with

``` C#
        public byte[] GetRaw(string key)
        {
            return Write(RedisCommand.GetRaw(key));
        }
```

and RedisCommand with:

``` C#
        public static RedisBytes GetRaw(string key)
        {
            return new RedisBytes("GET", key);
        }
```

in order to read byte arrays. This solution is limited to special cases. For instance it does not work for MGet, because RedisReader.Read always encodes bulk messages as text strings. The solution does neither apply to pub/sub messages.

This pull request proposes an alternative solution: it makes the string encoding of RedisReader configurable. Binary byte strings can be treated as C# text strings if the encoding supports 8 bits per character and if the number of bytes is the same as the number of characters. It appears that the old Windows-1252 encoding has these properties.

The changes are:
- RedisReader accesses the already existing RedisConnection._encoding
- reader functions that end with UTF8 are renamed to end with String instead (e.g. ReadBulkString instead of ReadBulkUTF8)
- RedisClient offers the configuration option Encoding that sets RedisConnection._encoding (don't know if RedisClient is the best place for this or if the encoding should be configured somewhere else)
- RedisClientTests.RedisStringTests have been extended with TestByteString for the configurable encoding

The default encoding remains UTF8, which is great for international characters. Alternatively one can now configure e.g. Windows-1252, in order to treat binary byte strings. When the encoding is changed to binary safe, then one can still have international characters by applying UTF8 encoding before passing the byte string to csredis. 

The solution works alike for get/set, mget/mset and pub/sub.

Would it be possible to accept this pull request or to otherwise support binary byte strings in the nice Redis like API of csredis?
