### PR TITLE
fixed floating-point parsing problems that happens in systems with non en-US cultures

### DIFF
--- a/CSRedis/RedisClient.cs
+++ b/CSRedis/RedisClient.cs
@@ -1,4 +1,6 @@
-﻿using CSRedis.Internal;
+﻿using System.Globalization;
+using System.Threading;
+using CSRedis.Internal;
 using System;
 using System.Text;
 using System.Threading.Tasks;
@@ -132,6 +134,10 @@ namespace CSRedis
 
         internal RedisClient(IRedisConnector connector, Encoding encoding)
         {
+            // use invariant culture - we have to set it explicitly for every thread we create to 
+            // prevent any floating-point problems (mostly because of number formats in non en-US cultures).
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+
             _connection = new RedisConnection(connector, encoding);
             _transaction = new RedisTransaction(_connection);
             _subscription = new SubscriptionListener(_connection);


### PR DESCRIPTION
- Related to #14
- Tests now run fine on non en-US systems.
