### PR TITLE
Derive RedisAsyncCommandTask from TaskCompletionSource.

### DIFF
--- a/CSRedis/Internal/RedisAsyncCommandToken.cs
+++ b/CSRedis/Internal/RedisAsyncCommandToken.cs
@@ -1,43 +1,31 @@
 ﻿using CSRedis.Internal.IO;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace CSRedis.Internal
 {
     interface IRedisAsyncCommandToken
     {
-        Task Task { get; }
         RedisCommand Command { get; }
         void SetResult(RedisReader reader);
         void SetException(Exception e);
+        bool TrySetException(Exception e);
     }
 
-    class RedisAsyncCommandToken<T> : IRedisAsyncCommandToken
+    class RedisAsyncCommandToken<T> : TaskCompletionSource<T>, IRedisAsyncCommandToken
     {
-        readonly TaskCompletionSource<T> _tcs;
         readonly RedisCommand<T> _command;
 
-        public TaskCompletionSource<T> TaskSource { get { return _tcs; } }
         public RedisCommand Command { get { return _command; } }
-        public Task Task { get { return _tcs.Task; } }
 
         public RedisAsyncCommandToken(RedisCommand<T> command)
         {
-            _tcs = new TaskCompletionSource<T>();
             _command = command;
         }
 
         public void SetResult(RedisReader reader)
         {
-            _tcs.SetResult(_command.Parse(reader));
-        }
-
-        public void SetException(Exception e)
-        {
-            _tcs.SetException(e);
+            SetResult(_command.Parse(reader));
         }
     }
 }

--- a/CSRedis/Internal/RedisConnector.cs
+++ b/CSRedis/Internal/RedisConnector.cs
@@ -135,7 +135,7 @@ namespace CSRedis.Internal
             var token = new RedisAsyncCommandToken<T>(command);
             AsyncWriteQueue.Enqueue(token);
             ConnectAsync().ContinueWith(CallAsyncDeferred);
-            return token.TaskSource.Task;
+            return token.Task;
         }
 
         public void Write(RedisCommand command)
@@ -316,7 +316,7 @@ namespace CSRedis.Internal
                     }
                     catch (Exception e)
                     {
-                        token.SetException(e);
+                        token.TrySetException(e);
                     }
                 }
             }


### PR DESCRIPTION
This saves an allocation and lets us more easily use TrySetException().
