### PR TITLE
Use the hostname portion of the sentinel address string, and not the whole address string when adding a host.

### DIFF
--- a/CSRedis/RedisSentinelManager.cs
+++ b/CSRedis/RedisSentinelManager.cs
@@ -35,7 +35,7 @@ namespace CSRedis
                 string[] parts = host.Split(':');
                 string hostname = parts[0].Trim();
                 int port = Int32.Parse(parts[1]);
-                Add(host, port);
+                Add(hostname, port);
             }
         }
 


### PR DESCRIPTION
It looks like the wrong variable was (is) used in error.