### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,28 @@
-##csredis 3.2.6
+## csredis 3.2.6
 **[new]** SSL Support
 
-##csredis 3.2.5
+## csredis 3.2.5
 **[new]** RedisConnectionPool: a pooled collection of Redis connections
 **[fix]** Public interface inheritance
 **[change]** Compatibility for sever 2.8.14
 **[new]** Exposing host/port
 **[fix]** Internal reorganization
 
-##csredis 3.2.1
+## csredis 3.2.1
 **[fix]** Unnecessary memory allocation when not using async methods  
 
-##csredis 3.1.18
+## csredis 3.1.18
 **[fix]** Encoding issues  
 **[new]** Strongname signed assembly available on NuGet  
 
-##csredis 3.1.1
+## csredis 3.1.1
 **[breaking]** Changed RedisClient.Connected property to RedisClient.IsConnected  
 **[breaking]** Changed RedisClient.Reconnected event to RedisClient.Connected. Event is now raised when the connection is first established as well as when the connection reconnects  
 **[breaking]** Changed RedisClient.ReconnectTimeout to RedisClient.ReconnectWait  
 **[fix]** Fixes to async handling  
 **[fix]** Fixes to pipeline handling  
 
-##csredis 3.0.0.0
+## csredis 3.0.0.0
 Major internal rewrite with several breaking changes. Upgrade with care!  
 **[breaking]** Changed base namespace: CSRedis  
 **[breaking]** Consolidated async methods into main client (removed RedisClientAsync)  
@@ -32,14 +32,14 @@ Major internal rewrite with several breaking changes. Upgrade with care!
 **[fix]** Improved async handling  
 **[fix]** Better support for Sentinel and managed connections  
 
-##csredis 2.1.1.0
+## csredis 2.1.1.0
 Added support for Redis 2.8 commands (SCAN, SSCAN, HSCAN, ZSCAN)
 
-##csredis 2.1.0.0
+## csredis 2.1.0.0
 Improved serialization performance  
 Added support for ISerializable  
 
-##csredis 2.0.0.0
+## csredis 2.0.0.0
 Improved handling of pipeline and MULTI/EXEC result parsing.  
 Breaking change: RedisClient.Multi() returns void instead of string. MULTI server reply may be observed by attaching to TransactionStarted event  
 RedisClient.StartPipe() now accepts optional boolean indicating whether or not result parsing should occur.  
@@ -48,38 +48,38 @@ RedisClient.EndPipe(bool) has no effect and should not be used
 RedisClient constructor overloads added to handle default values for port and timeout  
 TransactionQueuedEventArgs now includes the command and arguments that were queued.  
 
-##csredis 1.4.7.1
+## csredis 1.4.7.1
 Fixed bug in tracing for empty stack
 
-##csredis 1.4.7.0
+## csredis 1.4.7.0
 Added tracing
 
-##csredis 1.4.6.0
+## csredis 1.4.6.0
 Better handling of sorted set members in ZREM
 
-##csredis 1.4.5.0
+## csredis 1.4.5.0
 Better handling of sorted set scores in ZADD
 
-##csredis 1.4.4.0
+## csredis 1.4.4.0
 Fix for non-existent hashes now returns null
 
-##csredis 1.4.3.0
+## csredis 1.4.3.0
 Fix for null keys/values in hashes
 
-##csredis 1.4.2.0
+## csredis 1.4.2.0
 Added XML inline documentation
 
-##csredis 1.4.1.0
+## csredis 1.4.1.0
 Added support for extended SET command introduced in Redis 2.6.12
 
-##csredis 1.4.0.0
+## csredis 1.4.0.0
 Added async subscriptions and transactions
 
-##csredis 1.3.0.0
+## csredis 1.3.0.0
 Fixed byte streaming bug in RedisClient
 
-##csredis 1.2.0.0
+## csredis 1.2.0.0
 Fixed bug when reading large amounts of data concurrently
 
-##csredis 1.1.0.0
+## csredis 1.1.0.0
 Added async subscriptions and transactions

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ using (IRedisClientAsync csredis = new RedisClient(Host))
 }
 ```
 
-##Pipelining
+## Pipelining
 CSRedis supports pipelining commands to lessen the effects of network overhead on sequential server calls. To enable pipelining, wrap a group of commands between **StartPipe()** and **EndPipe()**. Note that redis-server currently has a 1GB limit on client buffers but CSRedis does not enforce this. Similar performance gains may be obtained by using the deferred Task/Asyncronous methods.
 ```csharp
 using (var redis = new RedisClient("localhost"))
@@ -76,17 +76,17 @@ using (var redis = new RedisClient("localhost"))
 ```
 
 
-##Why csredis?
+## Why csredis?
 There are a handful of .NET redis clients in active development, but none quite suited my needs: clean interface of the native Redis API; Sentinel support; easy-to-use pipelining/async. If there are gaps between CSRedis and another implementation please open an Issue or Pull Request.
 
 
-##Authentication
+## Authentication
 Password authentication is handled according to the native API (i.e. not in the connection constructor):
 ```csharp
 redis.Auth("mystrongpasword");
 ```
 
-##Reconnecting
+## Reconnecting
 CSRedis supports a simple reconnect option to handle dropped connections to the same Redis host. See **RedisSentinelManager** for a fuller implementation between multiple masters.
 ```csharp
 using (var redis = new RedisClient("localhost"))
@@ -98,7 +98,7 @@ using (var redis = new RedisClient("localhost"))
 }
 ```
 
-##Flexible hash mapping
+## Flexible hash mapping
 Pass any POCO or anonymous object to the generic hash methods:
 ```chsarp
 redis.HMSet("myhash", new
@@ -129,7 +129,7 @@ redis.HMSet("myhash", new[] { "F1", "string", "F2", "true", "F3", DateTime.Now.T
 ```
 
 
-##Transactions
+## Transactions
 Synchronous transactions are handled using the API calls MULTI/EXEC/DISCARD. Attach an event handler to **RedisClient.TransactionQueued** event to observe server queue replies (typically 'OK'). When inside of a transaction, command return values will be default(T).
 ```csharp
 redis.TransactionQueued += (s, e) =>
@@ -147,7 +147,7 @@ var item3 = (DateTime)result[2];
 ```
 
 
-##Subscription model
+## Subscription model
 The subscription model is event based. Attach a handler to one or both of SubscriptionChanged/SubscriptionReceived to receive callbacks on subscription events. Opening the first subscription channel blocks the main thread, so unsubscription (and new subscriptions) must be handled by a background thread/task.
 
 **SubscriptionChanged**: Occurs when a subsciption channel is opened or closed  
@@ -166,7 +166,7 @@ redis.SubscriptionReceived += (s, e) =>
 redis.PSubscribe("*");
 ```
 
-##Future-proof
+## Future-proof
 CSRedis exposes a basic **Call()** method that sends arbitrary commands to the Redis server. Use this command to easily implement future Redis commands before they are included in CSRedis. This can also be used to work with "bare-metal" server responses or if a command has been renamed in redis.conf.
 ```csharp
 object resp = redis.Call("ANYTHING", "arg1", "arg2", "arg3");
@@ -174,7 +174,7 @@ object resp = redis.Call("ANYTHING", "arg1", "arg2", "arg3");
 Note that the response object will need to be cast according to the Redis unified protocol: status (System.String), integer (System.Int64), bulk (System.String), multi-bulk (System.Object[]).
 
 
-##Streaming responses
+## Streaming responses
 For large result sizes, it may be preferred to stream the raw bytes from the server rather than allocating large chunks of memory in place. This can be achieved with **RedisClient.StreamTo()**. Note that this only applies to BULK responses (e.g. GET, HGET, LINDEX, etc). Attempting to stream any other response will result in an InvalidOperationException. Here is an example that stores the response in a MemoryStream 64 bytes at a time. A more useful example might use a FileStream and a larger buffer size.
 ```csharp
 redis.Set("test", new string('x', 1048576)); // 1MB string
@@ -185,11 +185,11 @@ using (var ms = new MemoryStream())
 }
 ```
 
-##Tracing
+## Tracing
 Use [.NET tracing](http://msdn.microsoft.com/en-us/library/ms733025(v=vs.110).aspx) to expose low level TCP messages
 
 
-##Sentinel
+## Sentinel
 **RedisSentinelManager** is a managed connection that will automatically obtain a connection to a Redis master node based on information from one or more Redis Sentinel nodes. Async methods coming soon
 ```csharp
 using (var sentinel = new RedisSentinelManager("host1:123", "host2:456"))


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
