### PR TITLE
Only Dispose of RedisSocket._socket when set

### DIFF
--- a/CSRedis/Internal/IO/RedisSocket.cs
+++ b/CSRedis/Internal/IO/RedisSocket.cs
@@ -64,7 +64,8 @@ namespace CSRedis.Internal.IO
 
         public void Dispose()
         {
-            _socket.Dispose();
+            if (_socket != null)
+                _socket.Dispose();
         }
 
         void InitSocket(EndPoint endpoint)


### PR DESCRIPTION
This would cause an exception when _socket was unset

In my case this happened when Thread.Abort()'ing a blocking Subscribe thread