### PR TITLE
Add support to mapping between internal and external IP's and Validate fileds from 'SENTINEL sentinels' command

### DIFF
--- a/CSRedis/RedisSentinelManager.cs
+++ b/CSRedis/RedisSentinelManager.cs
@@ -17,6 +17,7 @@ namespace CSRedis
         string _masterName;
         int _connectTimeout;
         RedisClient _redisClient;
+        Dictionary<string, string> _hostMapping;
 
         /// <summary>
         /// Occurs when the master connection has sucessfully connected
@@ -46,6 +47,22 @@ namespace CSRedis
         public void Add(string host)
         {
             Add(host, DefaultPort);
+        }
+
+        /// <summary>
+        /// Add host mapping for the internal IP returned by Sentinel to the external IP
+        /// </summary>
+        /// <param name="hostMapping">Dictionary of sentinel host mapping between internal and external IPs</param>
+        public void AddHostMapping(Dictionary<string, string> hostMapping)
+        {
+            _hostMapping = hostMapping;
+        }
+
+        private string MapHost(string host)
+        {
+            if (_hostMapping != null && _hostMapping.ContainsKey(host))
+                return _hostMapping[host];
+            return host;
         }
 
         /// <summary>

--- a/CSRedis/Types.cs
+++ b/CSRedis/Types.cs
@@ -403,10 +403,24 @@ namespace CSRedis
             Port = info.GetInt32("port");
             RunId = info.GetString("runid");
             Flags = info.GetString("flags").Split(',');
-            PendingCommands = info.GetInt64("pending-commands");
+            PendingCommands = Exists(info, "pending-commands")? info.GetInt64("pending-commands"): info.GetInt64("link-pending-commands");
             LastOkPingReply = info.GetInt64("last-ok-ping-reply");
             LastPingReply = info.GetInt64("last-ping-reply");
             DownAfterMilliseconds = info.GetInt64("down-after-milliseconds");
+        }
+
+        /// <summary>
+        /// Check if key exists in SerializationInfo
+        /// </summary>
+        /// <param name="info">SerializationInfo object</param>
+        /// <param name="key">The key to check</param>
+        /// <returns>Return true if key exists in SerializationInfo object</returns>
+        protected static bool Exists(SerializationInfo info, string key)
+        {
+            foreach(var entry in info)
+                if (entry.Name == key)
+                    return true;
+            return false;
         }
 
         /// <summary>
@@ -618,7 +632,8 @@ namespace CSRedis
         public RedisSentinelInfo(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            SDownTime = info.GetInt64("s-down-time");
+            if(Exists(info, "s-down-time"))
+                SDownTime = info.GetInt64("s-down-time");
             LastHelloMessage = info.GetInt64("last-hello-message");
             VotedLeader = info.GetString("voted-leader");
             VotedLeaderEpoch = info.GetInt64("voted-leader-epoch");


### PR DESCRIPTION
In case sentinels are communicating with each other with internal IP there is a need to add host mapping to external IP so when sentinel returns the IP of redis master it will be accessible for hosts out side.
Usage example:

`var sentinel = new RedisSentinelManager();
sentinel.AddHostMapping(new System.Collections.Generic.Dictionary<string, string>
            {
                { "10.0.0.1", "35.36.37.38" },
                { "10.0.0.2", "35.36.37.39" },
                { "10.0.0.3", "35.36.37.40" }
            });
`

In addition, fix renamed or moved fields in 'SENTINEL sentinel' command.
for example see "pending-commands" => "link-pending-commands":
[https://groups.google.com/forum/#!topic/redis-db/24GIAEvW9VU](url)

